### PR TITLE
Update SSDP model attribute reference

### DIFF
--- a/custom_components/samsungwam/config_flow.py
+++ b/custom_components/samsungwam/config_flow.py
@@ -9,6 +9,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components import ssdp
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers import service_info
 from homeassistant.const import (
     CONF_HOST,
     CONF_MODEL,
@@ -87,7 +88,7 @@ class SamsungWamConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Upnp data
         host = urlparse(discovery_info.ssdp_location).hostname
-        ssdp_model = discovery_info.upnp.get(ssdp.ATTR_UPNP_MODEL_NAME)
+        ssdp_model = discovery_info.upnp.get(service_info.ssdp.ATTR_UPNP_MODEL_NAME)
         # serial_number = discovery_info.upnp.get(ssdp.ATTR_UPNP_SERIAL)
 
         # Speaker info from pywam


### PR DESCRIPTION
This corrects the issue with the deprecated constant, which can be found someplace else now. Should fix issue #8 